### PR TITLE
fix: validate signatures against current owners after removal

### DIFF
--- a/contracts/src/MultiSigWallet.sol
+++ b/contracts/src/MultiSigWallet.sol
@@ -94,7 +94,15 @@ contract MultiSigWallet {
 
         Transaction storage txn = sTransactions[txId];
         if (txn.executed) revert AlreadyExecuted();
-        if (txn.signatureCount < threshold) revert NotEnoughSignatures();
+
+        uint256 validSignatures = 0;
+        uint256 ownerCount = sOwners.length;
+        for (uint256 i = 0; i < ownerCount; i++) {
+            if (sSigned[txId][sOwners[i]]) {
+                validSignatures++;
+            }
+        }
+        if (validSignatures < threshold) revert NotEnoughSignatures();
 
         txn.executed = true;
         (bool success, ) = txn.to.call{value: txn.value}(txn.data);
@@ -164,6 +172,16 @@ contract MultiSigWallet {
     function hasSigned(uint256 txId, address owner) external view returns (bool) {
         if (txId >= sTransactions.length) revert TxDoesNotExist();
         return sSigned[txId][owner];
+    }
+
+    function getValidSignatureCount(uint256 txId) external view returns (uint256 count) {
+        if (txId >= sTransactions.length) revert TxDoesNotExist();
+        uint256 ownerCount = sOwners.length;
+        for (uint256 i = 0; i < ownerCount; i++) {
+            if (sSigned[txId][sOwners[i]]) {
+                count++;
+            }
+        }
     }
 
     function _setOwners(address[] memory owners_) private {

--- a/contracts/test/MultiSigWallet.t.sol
+++ b/contracts/test/MultiSigWallet.t.sol
@@ -107,3 +107,132 @@ contract MultiSigWalletTest is Test {
         assertEq(wallet.threshold(), 2);
     }
 }
+
+contract MultiSigWalletStaleSignatureTest is Test {
+    MultiSigWallet internal wallet;
+
+    address internal alice = makeAddr("alice");
+    address internal bob = makeAddr("bob");
+    address internal carol = makeAddr("carol");
+    address internal recipient = makeAddr("recipient");
+
+    function setUp() public {
+        address[] memory owners = new address[](3);
+        owners[0] = alice;
+        owners[1] = bob;
+        owners[2] = carol;
+        wallet = new MultiSigWallet(owners, 3);
+        vm.deal(address(wallet), 10 ether);
+    }
+
+    /// @dev Helper to execute a self-targeting governance tx (requires all 3 sigs)
+    function _executeGovernanceTx(bytes memory data) internal {
+        vm.prank(alice);
+        uint256 txId = wallet.submitTransaction(address(wallet), 0, data);
+
+        vm.prank(alice);
+        wallet.signTransaction(txId);
+        vm.prank(bob);
+        wallet.signTransaction(txId);
+        vm.prank(carol);
+        wallet.signTransaction(txId);
+
+        vm.prank(alice);
+        wallet.executeTransaction(txId);
+    }
+
+    function testRemovedOwnerSignatureDoesNotCountTowardThreshold() public {
+        // Submit a transfer tx and have bob + carol sign (2 sigs)
+        vm.prank(alice);
+        uint256 txId = wallet.submitTransaction(recipient, 1 ether, "");
+
+        vm.prank(bob);
+        wallet.signTransaction(txId);
+        vm.prank(carol);
+        wallet.signTransaction(txId);
+
+        // Remove bob via governance (threshold auto-reduces from 3 to 2)
+        _executeGovernanceTx(abi.encodeCall(MultiSigWallet.removeOwner, (bob)));
+        assertEq(wallet.threshold(), 2);
+
+        // Now only carol's signature is valid (1 valid sig < threshold 2)
+        // Without the fix, signatureCount=2 >= threshold=2 would pass
+        vm.prank(alice);
+        vm.expectRevert(MultiSigWallet.NotEnoughSignatures.selector);
+        wallet.executeTransaction(txId);
+    }
+
+    function testStaleSignaturesIgnoredAfterMultipleRemovals() public {
+        // Submit tx, bob and carol sign (not alice)
+        vm.prank(alice);
+        uint256 txId = wallet.submitTransaction(recipient, 1 ether, "");
+
+        vm.prank(bob);
+        wallet.signTransaction(txId);
+        vm.prank(carol);
+        wallet.signTransaction(txId);
+
+        // Remove carol (threshold 3 -> 2)
+        _executeGovernanceTx(abi.encodeCall(MultiSigWallet.removeOwner, (carol)));
+
+        // Remove bob (threshold 2 -> 1)
+        // Need governance tx with alice + bob signing (threshold is now 2)
+        vm.prank(alice);
+        uint256 removeBobTx = wallet.submitTransaction(
+            address(wallet), 0, abi.encodeCall(MultiSigWallet.removeOwner, (bob))
+        );
+        vm.prank(alice);
+        wallet.signTransaction(removeBobTx);
+        vm.prank(bob);
+        wallet.signTransaction(removeBobTx);
+        vm.prank(alice);
+        wallet.executeTransaction(removeBobTx);
+
+        assertEq(wallet.threshold(), 1);
+
+        // 0 valid signatures remain (bob and carol both removed), alice never signed
+        // Without fix: signatureCount=2 >= threshold=1 would pass
+        vm.prank(alice);
+        vm.expectRevert(MultiSigWallet.NotEnoughSignatures.selector);
+        wallet.executeTransaction(txId);
+    }
+
+    function testValidSignaturesStillWorkAfterUnrelatedOwnerRemoval() public {
+        // Submit tx, alice and bob sign
+        vm.prank(alice);
+        uint256 txId = wallet.submitTransaction(recipient, 1 ether, "");
+
+        vm.prank(alice);
+        wallet.signTransaction(txId);
+        vm.prank(bob);
+        wallet.signTransaction(txId);
+
+        // Remove carol (not a signer on this tx). Threshold 3 -> 2
+        _executeGovernanceTx(abi.encodeCall(MultiSigWallet.removeOwner, (carol)));
+
+        // alice and bob are still valid owners with valid sigs (2 >= 2)
+        vm.prank(alice);
+        wallet.executeTransaction(txId);
+
+        assertEq(recipient.balance, 1 ether);
+    }
+
+    function testGetValidSignatureCount() public {
+        vm.prank(alice);
+        uint256 txId = wallet.submitTransaction(recipient, 1 ether, "");
+
+        vm.prank(alice);
+        wallet.signTransaction(txId);
+        vm.prank(bob);
+        wallet.signTransaction(txId);
+
+        // Before removal: 2 valid sigs (alice + bob)
+        assertEq(wallet.getValidSignatureCount(txId), 2);
+
+        // Remove bob
+        _executeGovernanceTx(abi.encodeCall(MultiSigWallet.removeOwner, (bob)));
+
+        // After removal: only 1 valid sig (alice), even though signatureCount is still 2
+        assertEq(wallet.getValidSignatureCount(txId), 1);
+    }
+}

--- a/frontend/components/transaction-card.tsx
+++ b/frontend/components/transaction-card.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { toast } from "sonner";
+import { useReadContract } from "wagmi";
 
 import type { WalletTransaction } from "@/lib/hooks/use-wallet-transactions";
 import { useMultisigActions } from "@/lib/hooks/use-multisig-actions";
 import { txExplorerUrl } from "@/lib/utils/explorer";
+import { multisigAbi } from "@/lib/contracts/multisig-abi";
 
 import { TransactionSigners } from "@/components/transaction-signers";
 
@@ -17,7 +19,15 @@ type Props = {
 
 export const TransactionCard = ({ tx, walletAddress, owners, threshold }: Props) => {
   const { execute, sign, isPending } = useMultisigActions(walletAddress);
-  const canExecute = tx.signatureCount >= threshold && !tx.executed;
+  const { data: validSigCount } = useReadContract({
+    abi: multisigAbi,
+    address: walletAddress,
+    functionName: "getValidSignatureCount",
+    args: [tx.id],
+    query: { enabled: !tx.executed, refetchInterval: 4_000 }
+  });
+  const sigCount = validSigCount ?? tx.signatureCount;
+  const canExecute = sigCount >= threshold && !tx.executed;
   const statusClass = tx.executed
     ? "bg-[hsl(var(--success))]/15 text-[hsl(var(--success))]"
     : "bg-[hsl(var(--warning))]/14 text-[hsl(var(--warning))]";
@@ -37,7 +47,7 @@ export const TransactionCard = ({ tx, walletAddress, owners, threshold }: Props)
         </p>
         <p>Value: {tx.value.toString()} wei</p>
         <p>
-          Signatures: {tx.signatureCount.toString()} / {threshold.toString()}
+          Signatures: {sigCount.toString()} / {threshold.toString()}
         </p>
       </div>
 

--- a/frontend/lib/contracts/multisig-abi.ts
+++ b/frontend/lib/contracts/multisig-abi.ts
@@ -88,5 +88,12 @@ export const multisigAbi = [
     stateMutability: "nonpayable",
     inputs: [{ name: "newThreshold", type: "uint256" }],
     outputs: []
+  },
+  {
+    type: "function",
+    name: "getValidSignatureCount",
+    stateMutability: "view",
+    inputs: [{ name: "txId", type: "uint256" }],
+    outputs: [{ name: "count", type: "uint256" }]
   }
 ] as const;


### PR DESCRIPTION
## Summary
- **Fixes H-1/H-2** from Cygent audit: stale signatures from removed owners were persisting in `sSigned` and satisfying reduced thresholds after `removeOwner`
- `executeTransaction` now recomputes valid signatures by iterating current `sOwners` instead of trusting cached `signatureCount`
- Adds `getValidSignatureCount` view function for frontend accuracy
- Frontend updated to use `getValidSignatureCount` for display and execute button logic
- **H-3 marked invalid**: duplicate transactions are by-design (matches Gnosis Safe behavior)

## Test plan
- [x] 4 new tests covering the exploit scenario, multiple removals, positive regression, and the view function
- [x] All 8 tests pass (`forge test`)
- [ ] Manual verification on Sepolia after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)